### PR TITLE
Replace RFC1123 with RFC1123Z plus some upstream changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,47 +14,50 @@ Web feed generator library.
 
 ```go
 
-import (
-    "fmt"
-    "time"
-    "github.com/gorilla/feeds"
-)
+package main {
 
-now := time.Now()
-feed := &feeds.Feed{
-    Title:       "jmoiron.net blog",
-    Link:        &feeds.Link{Href: "http://jmoiron.net/blog"},
-    Description: "discussion about tech, footie, photos",
-    Author:      &feeds.Author{"Jason Moiron", "jmoiron@jmoiron.net"},
-    Created:     now,
-}
+    import (
+        "fmt"
+        "time"
+        "github.com/gorilla/feeds"
+    )
 
-feed.Items = []*feeds.Item{
-    &feeds.Item{
-        Title:       "Limiting Concurrency in Go",
-        Link:        &feeds.Link{Href: "http://jmoiron.net/blog/limiting-concurrency-in-go/"},
-        Description: "A discussion on controlled parallelism in golang",
+    now := time.Now()
+    feed := &feeds.Feed{
+        Title:       "jmoiron.net blog",
+        Link:        &feeds.Link{Href: "http://jmoiron.net/blog"},
+        Description: "discussion about tech, footie, photos",
         Author:      &feeds.Author{"Jason Moiron", "jmoiron@jmoiron.net"},
         Created:     now,
-    },
-    &feeds.Item{
-        Title:       "Logic-less Template Redux",
-        Link:        &feeds.Link{Href: "http://jmoiron.net/blog/logicless-template-redux/"},
-        Description: "More thoughts on logicless templates",
-        Created:     now,
-    },
-    &feeds.Item{
-        Title:       "Idiomatic Code Reuse in Go",
-        Link:        &feeds.Link{Href: "http://jmoiron.net/blog/idiomatic-code-reuse-in-go/"},
-        Description: "How to use interfaces <em>effectively</em>",
-        Created:     now,
-    },
+    }
+
+    feed.Items = []*feeds.Item{
+        &feeds.Item{
+            Title:       "Limiting Concurrency in Go",
+            Link:        &feeds.Link{Href: "http://jmoiron.net/blog/limiting-concurrency-in-go/"},
+            Description: "A discussion on controlled parallelism in golang",
+            Author:      &feeds.Author{"Jason Moiron", "jmoiron@jmoiron.net"},
+            Created:     now,
+        },
+        &feeds.Item{
+            Title:       "Logic-less Template Redux",
+            Link:        &feeds.Link{Href: "http://jmoiron.net/blog/logicless-template-redux/"},
+            Description: "More thoughts on logicless templates",
+            Created:     now,
+        },
+        &feeds.Item{
+            Title:       "Idiomatic Code Reuse in Go",
+            Link:        &feeds.Link{Href: "http://jmoiron.net/blog/idiomatic-code-reuse-in-go/"},
+            Description: "How to use interfaces <em>effectively</em>",
+            Created:     now,
+        },
+    }
+
+    atom, _ := feed.ToAtom()  // _ parameter is err
+    rss, _  := feed.ToRss()   // _ parameter is err
+
+    fmt.Println(atom, "\n", rss)
 }
-
-atom, err := feed.ToAtom()
-rss, err := feed.ToRss()
-
-fmt.Println(atom, "\n", rss)
 
 ```
 

--- a/atom.go
+++ b/atom.go
@@ -74,7 +74,7 @@ type AtomFeed struct {
 	Rights      string   `xml:"rights,omitempty"` // copyright used
 	Subtitle    string   `xml:"subtitle,omitempty"`
 	Link        *AtomLink
-	Author      *AtomAuthor // required 
+	Author      *AtomAuthor `xml:"author,omitempty"`
 	Contributor *AtomContributor
 	Entries     []*AtomEntry
 }
@@ -133,8 +133,6 @@ func (a *Atom) AtomFeed() *AtomFeed {
 	}
 	if a.Author != nil {
 		feed.Author = &AtomAuthor{AtomPerson: AtomPerson{Name: a.Author.Name, Email: a.Author.Email}}
-	} else {
-		feed.Author = &AtomAuthor{AtomPerson: AtomPerson{Name: "", Email: ""}}
 	}
 	for _, e := range a.Items {
 		feed.Entries = append(feed.Entries, newAtomEntry(e))

--- a/feed.go
+++ b/feed.go
@@ -3,7 +3,6 @@ package feeds
 import (
 	"encoding/xml"
 	"io"
-	"strings"
 	"time"
 )
 
@@ -55,9 +54,7 @@ func (f *Feed) Add(item *Item) {
 func anyTimeFormat(format string, times ...time.Time) string {
 	for _, t := range times {
 		if !t.IsZero() {
-			// Always return GMT time by converting to UTC and then replacing UTC with GMT in the output string (RSS doesn't allow UTC)
-			timeFormatted := t.UTC().Format(format)
-			return strings.Replace(timeFormatted, "UTC", "GMT", -1)
+			return t.Format(format)
 		}
 	}
 	return ""

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,62 @@
+
+// +build gofuzz
+
+package feeds
+
+import (
+	"bytes"
+	"time"
+)
+
+func Fuzz(input []byte) int {
+	s := string(input)
+	now, err := time.Parse(time.RFC3339, "2013-01-16T21:52:35-05:00")
+	if err != nil {
+		panic(err)
+	}
+	tz := time.FixedZone("EST", -5*60*60)
+	now = now.In(tz)
+
+	feed := &Feed{
+		Title: s,
+		Link: &Link{Href: s},
+		Description: s,
+		Author: &Author{Name: s, Email: s},
+		Created: now,
+		Copyright: s,
+	}
+	
+	feed.Items = []*Item{
+		{
+			Title:       s,
+			Link:        &Link{Href: s},
+			Description: s,
+			Author:      &Author{Name: s, Email: s},
+			Created:     now,
+		},
+		{
+			Title:       s,
+			Link:        &Link{Href: s},
+			Description: s,
+			Created:     now,
+		}}
+
+	_, err = feed.ToAtom()
+	if err != nil {
+		panic(err)
+	}
+	var buf bytes.Buffer
+	if err := feed.WriteAtom(&buf); err != nil {
+		panic(err)
+	}
+
+	_, err = feed.ToRss()
+	if err != nil {
+		panic(err)
+	}
+	buf.Reset()
+	if err := feed.WriteRss(&buf); err != nil {
+		panic(err)
+	}
+	return 1
+}

--- a/rss.go
+++ b/rss.go
@@ -142,7 +142,7 @@ func newRssItem(i *Item) *RssItem {
 			IsPermaLink: false,
 			Value:       i.Id,
 		},
-		PubDate: anyTimeFormat(time.RFC1123, i.Created, i.Updated),
+		PubDate: anyTimeFormat(time.RFC1123Z, i.Created, i.Updated),
 	}
 	if i.Author != nil {
 		item.Author = i.Author.Name
@@ -155,8 +155,8 @@ func newRssItem(i *Item) *RssItem {
 
 // create a new RssFeed with a generic Feed struct's data
 func (r *Rss) RssFeed() *RssFeed {
-	pub := anyTimeFormat(time.RFC1123, r.Created)
-	build := anyTimeFormat(time.RFC1123, r.Updated)
+	pub := anyTimeFormat(time.RFC1123Z, r.Created)
+	build := anyTimeFormat(time.RFC1123Z, r.Updated)
 	author := ""
 	if r.Author != nil {
 		author = r.Author.Email


### PR DESCRIPTION
From https://godoc.org/time:

> In general RFC1123Z should be used instead of RFC1123 for servers that insist on that format, and RFC3339 should be preferred for new protocols.

No more UTC to GMT string replace hack.
